### PR TITLE
type improvements, export constant helpers

### DIFF
--- a/client.go
+++ b/client.go
@@ -23,9 +23,15 @@ const (
 	APIProdURL = "https://trading-api.kalshi.com/trade-api/v2/"
 )
 
-// Cents is a safety type to prevent dollars from being accidently passed into
-// the API.
-type Cents = int
+type Cents int
+
+func (c Cents) String() string {
+	return fmt.Sprintf("$%.2f", c.Dollars())
+}
+
+func (c Cents) Dollars() float32 {
+	return float32(c) / 100
+}
 
 // Client must be instantiated via New.
 type Client struct {
@@ -60,7 +66,7 @@ func jsonRequestHeaders(
 	client *http.Client,
 	headers http.Header,
 	method string, reqURL string,
-	jsonReq interface{}, jsonResp interface{},
+	jsonReq any, jsonResp any,
 ) error {
 	reqBodyByt, err := json.Marshal(jsonReq)
 	if err != nil {

--- a/client.go
+++ b/client.go
@@ -26,11 +26,8 @@ const (
 type Cents int
 
 func (c Cents) String() string {
-	return fmt.Sprintf("$%.2f", c.Dollars())
-}
-
-func (c Cents) Dollars() float32 {
-	return float32(c) / 100
+	dollars := float32(c) / 100
+	return fmt.Sprintf("$%.2f", dollars)
 }
 
 // Client must be instantiated via New.

--- a/feed.go
+++ b/feed.go
@@ -60,7 +60,7 @@ type orderBookDelta struct {
 		MarketID string `json:"market_id"`
 		Price    Cents  `json:"price"`
 		Delta    int    `json:"delta"`
-		Side     string `json:"side"`
+		Side     Side   `json:"side"`
 	}
 }
 
@@ -139,11 +139,11 @@ func (o *orderBookStreamState) OrderBook() *StreamOrderBook {
 	return &ob
 }
 
-func (o *orderBookStreamState) ApplyDelta(side string, price Cents, delta int) error {
+func (o *orderBookStreamState) ApplyDelta(side Side, price Cents, delta int) error {
 	var dir map[Cents]int
-	if side == "yes" {
+	if side == Yes {
 		dir = o.Yes
-	} else if side == "no" {
+	} else if side == No {
 		dir = o.No
 	} else {
 		return fmt.Errorf("unknown side: %v", side)

--- a/feed.go
+++ b/feed.go
@@ -49,8 +49,8 @@ type orderBookSnapshot struct {
 	subscriptionMessageHeader
 	Msg struct {
 		MarketID string        `json:"market_id"`
-		Yes      OrderBookSide `json:"yes"`
-		No       OrderBookSide `json:"no"`
+		Yes      OrderBookBids `json:"yes"`
+		No       OrderBookBids `json:"no"`
 	} `json:"msg"`
 }
 
@@ -94,7 +94,7 @@ func makeOrderBookStreamState(marketID string) orderBookStreamState {
 }
 
 // sortOrderBook performs an in-place sort of OrderBook.
-func sortOrderBookDirection(dir OrderBookSide) {
+func sortOrderBookDirection(dir OrderBookBids) {
 	sort.Slice(dir, func(i, j int) bool {
 		return dir[i].Price < dir[j].Price
 	})

--- a/market.go
+++ b/market.go
@@ -101,23 +101,23 @@ type Market struct {
 	CloseTime       time.Time `json:"close_time"`
 	ExpirationTime  time.Time `json:"expiration_time"`
 	Status          string    `json:"status"`
-	YesBid          int       `json:"yes_bid"`
-	YesAsk          int       `json:"yes_ask"`
-	NoBid           int       `json:"no_bid"`
-	NoAsk           int       `json:"no_ask"`
-	LastPrice       int       `json:"last_price"`
-	PreviousYesBid  int       `json:"previous_yes_bid"`
-	PreviousYesAsk  int       `json:"previous_yes_ask"`
-	PreviousPrice   int       `json:"previous_price"`
+	YesBid          Cents     `json:"yes_bid"`
+	YesAsk          Cents     `json:"yes_ask"`
+	NoBid           Cents     `json:"no_bid"`
+	NoAsk           Cents     `json:"no_ask"`
+	LastPrice       Cents     `json:"last_price"`
+	PreviousYesBid  Cents     `json:"previous_yes_bid"`
+	PreviousYesAsk  Cents     `json:"previous_yes_ask"`
+	PreviousPrice   Cents     `json:"previous_price"`
 	Volume          int       `json:"volume"`
 	Volume24H       int       `json:"volume_24h"`
-	Liquidity       int       `json:"liquidity"`
+	Liquidity       Cents     `json:"liquidity"`
 	OpenInterest    int       `json:"open_interest"`
 	Result          string    `json:"result"`
 	CanCloseEarly   bool      `json:"can_close_early"`
 	ExpirationValue string    `json:"expiration_value"`
 	Category        string    `json:"category"`
-	RiskLimitCents  int       `json:"risk_limit_cents"`
+	RiskLimit       Cents     `json:"risk_limit_cents"`
 	StrikeType      string    `json:"strike_type"`
 	FloorStrike     float64   `json:"floor_strike,omitempty"`
 	CapStrike       float64   `json:"cap_strike,omitempty"`
@@ -157,11 +157,11 @@ func (c *Client) Markets(
 type Trade struct {
 	Count       int       `json:"count"`
 	CreatedTime time.Time `json:"created_time"`
-	NoPrice     int       `json:"no_price"`
-	TakerSide   string    `json:"taker_side"`
+	NoPrice     Cents     `json:"no_price"`
+	TakerSide   Side      `json:"taker_side"`
 	Ticker      string    `json:"ticker"`
 	TradeID     string    `json:"trade_id"`
-	YesPrice    int       `json:"yes_price"`
+	YesPrice    Cents     `json:"yes_price"`
 }
 
 // TradesResponse is described here:
@@ -221,14 +221,14 @@ func (c *Client) Market(ctx context.Context, ticker string) (*Market, error) {
 // MarketHistory is described here:
 // https://trading-api.readme.io/reference/getmarkethistory.
 type MarketHistory struct {
-	NoAsk        int       `json:"no_ask"`
-	NoBid        int       `json:"no_bid"`
+	NoAsk        Cents     `json:"no_ask"`
+	NoBid        Cents     `json:"no_bid"`
 	OpenInterest int       `json:"open_interest"`
 	Ts           Timestamp `json:"ts"`
 	Volume       int       `json:"volume"`
-	YesAsk       int       `json:"yes_ask"`
-	YesBid       int       `json:"yes_bid"`
-	YesPrice     int       `json:"yes_price"`
+	YesAsk       Cents     `json:"yes_ask"`
+	YesBid       Cents     `json:"yes_bid"`
+	YesPrice     Cents     `json:"yes_price"`
 }
 
 // MarketHistoryResponse is described here:

--- a/orderbook.go
+++ b/orderbook.go
@@ -149,7 +149,7 @@ func conservativeRound(a float64) int {
 // Make sure you understand the market structure before using this struct.
 // A central feature of the Kalshi contract model is that a No bid corresponds
 // to a Yes ask of the complementary price. That is, a No bid at 40 cents
-// is eqivalent to a Yes ask at 60 cents. This OrderBook type is a
+// is equivalent to a Yes ask at 60 cents. This OrderBook type is a
 // a list of bids on either side.
 //
 // Detailed documentation can be found here:

--- a/orderbook.go
+++ b/orderbook.go
@@ -3,11 +3,11 @@ package kalshi
 import (
 	"encoding/json"
 	"fmt"
-	"math"
 )
 
-type OrderBookSide []OrderBookBid
+type OrderBookBids []OrderBookBid
 
+// OrderBookBid represents the aggregate quantity of all resting Bids at a given price.
 type OrderBookBid struct {
 	Price    Cents
 	Quantity int
@@ -30,8 +30,79 @@ func (o *OrderBookBid) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-// BestPrice returns the best price for average execution.
-func (b OrderBookSide) BestPrice(wantQuantity int) (Cents, bool) {
+func (b OrderBook) YesLiquidity() Cents {
+	return b.NoBids.liquidity()
+}
+
+func (b OrderBook) NoLiquidity() Cents {
+	return b.YesBids.liquidity()
+}
+
+// YesTotalOffers is the quantity of total Yes contracts available to be taken.
+func (b OrderBook) YesTotalOffers() int {
+	return b.NoBids.totalOffers()
+}
+
+// NoTotalOffers is the quantity of total No contracts available to be taken.
+func (b OrderBook) NoTotalOffers() int {
+	return b.YesBids.totalOffers()
+}
+
+// liquidity is in an internal method that calculates the liquidity a slice of bids
+// provides to takers on the opposite side of the market.
+func (b OrderBookBids) liquidity() Cents {
+	liquidity := Cents(0)
+	for i := 0; i < len(b); i++ {
+		liquidity += Cents(b[i].Quantity * int(100-b[i].Price))
+	}
+	return liquidity
+}
+
+func (b OrderBookBids) totalOffers() int {
+	total := 0
+	for i := 0; i < len(b); i++ {
+		total += b[i].Quantity
+	}
+	return total
+}
+
+func (b OrderBookBids) availableQuantity(limitPrice Cents) int {
+	quantity := 0
+	for i := len(b) - 1; i >= 0; i-- {
+		if 100-b[i].Price > limitPrice {
+			return quantity
+		}
+		quantity += b[i].Quantity
+	}
+	return quantity
+}
+
+// YesAvailableUnderLimit is the quantity of Yes contracts available to be taken
+// at a price less than or equal to the given limit.
+func (b OrderBook) YesAvailableUnderLimit(limit Cents) int {
+	return b.NoBids.availableQuantity(limit)
+}
+
+// NoAvailableUnderLimit is the quantity of No contracts available to be taken
+// at a price less than or equal to the given limit.
+func (b OrderBook) NoAvailableUnderLimit(limit Cents) int {
+	return b.YesBids.availableQuantity(limit)
+}
+
+// BestYesTake returns the best average
+// asking price for Yes contracts given a desired quantity.
+func (b OrderBook) BestYesTake(quantity int) (Cents, bool) {
+	return b.NoBids.bestPrice(quantity)
+}
+
+// BestNoTake returns the best average
+// asking price for No contracts given a desired quantity.
+func (b OrderBook) BestNoTake(quantity int) (Cents, bool) {
+	return b.YesBids.bestPrice(quantity)
+}
+
+// bestPrice returns the best price for average execution.
+func (b OrderBookBids) bestPrice(wantQuantity int) (Cents, bool) {
 	var (
 		foundQuantity int
 		weightedCum   int
@@ -56,7 +127,7 @@ func (b OrderBookSide) BestPrice(wantQuantity int) (Cents, bool) {
 
 		if foundQuantity == wantQuantity {
 			// We round up to be conservative.
-			return Cents(math.Round(float64(weightedCum) / float64(wantQuantity))), true
+			return Cents(conservativeRound(float64(weightedCum) / float64(wantQuantity))), true
 		} else if foundQuantity > wantQuantity {
 			panic(fmt.Sprintf("%+v %+v", foundQuantity, wantQuantity))
 		}
@@ -64,10 +135,25 @@ func (b OrderBookSide) BestPrice(wantQuantity int) (Cents, bool) {
 	return -1, false
 }
 
+func conservativeRound(a float64) int {
+	down := int(a)
+	if a-float64(down) > 0 {
+		return down + 1
+	}
+	return down
+}
+
 // OrderBook is a snapshot of the order book.
-// It is described here:
+//
+// Make sure you understand the market structure before using this struct.
+// A central feature of the Kalshi contract model is that a No bid corresponds
+// to a Yes ask of the complementary price. That is, a No bid at 40 cents
+// is eqivalent to a Yes ask at 60 cents. This OrderBook type is a
+// a list of bids on either side.
+//
+// Detailed documentation can be found here:
 // https://trading-api.readme.io/reference/getmarketorderbook.
 type OrderBook struct {
-	YesBids OrderBookSide `json:"yes"`
-	NoBids  OrderBookSide `json:"no"`
+	YesBids OrderBookBids `json:"yes"`
+	NoBids  OrderBookBids `json:"no"`
 }

--- a/orderbook.go
+++ b/orderbook.go
@@ -30,10 +30,14 @@ func (o *OrderBookBid) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+// YesLiquidity returns the total sum required to buy all available
+// Yes contracts on the market.
 func (b OrderBook) YesLiquidity() Cents {
 	return b.NoBids.liquidity()
 }
 
+// NoLiquidity returns the total sum required to buy all available
+// No contracts on the market.
 func (b OrderBook) NoLiquidity() Cents {
 	return b.YesBids.liquidity()
 }
@@ -58,6 +62,8 @@ func (b OrderBookBids) liquidity() Cents {
 	return liquidity
 }
 
+// totalOffers sums the quantity of contracts available to takers on the
+// opposite side of the market.
 func (b OrderBookBids) totalOffers() int {
 	total := 0
 	for i := 0; i < len(b); i++ {
@@ -66,6 +72,8 @@ func (b OrderBookBids) totalOffers() int {
 	return total
 }
 
+// offersUnderLimit sums the quantity of contracts available to takers on the
+// opposite side of the market at a price less than or equal to the given limit.
 func (b OrderBookBids) offersUnderLimit(limitPrice Cents) int {
 	quantity := 0
 	for i := len(b) - 1; i >= 0; i-- {
@@ -148,7 +156,7 @@ func conservativeRound(a float64) int {
 //
 // Make sure you understand the market structure before using this struct.
 // A central feature of the Kalshi contract model is that a No bid corresponds
-// to a Yes ask of the complementary price. That is, a No bid at 40 cents
+// to a Yes ask of the complementary price and vice versa. That is, a No bid at 40 cents
 // is equivalent to a Yes ask at 60 cents. This OrderBook type is a
 // a list of bids on either side.
 //

--- a/orderbook.go
+++ b/orderbook.go
@@ -89,15 +89,15 @@ func (b OrderBook) NoOffersUnderLimit(limit Cents) int {
 	return b.YesBids.offersUnderLimit(limit)
 }
 
-// BestYesTake returns the best average
+// BestYesOffer returns the best average
 // asking price for Yes contracts given a desired quantity.
-func (b OrderBook) BestYesTake(quantity int) (Cents, bool) {
+func (b OrderBook) BestYesOffer(quantity int) (Cents, bool) {
 	return b.NoBids.bestPrice(quantity)
 }
 
-// BestNoTake returns the best average
+// BestNoOffer returns the best average
 // asking price for No contracts given a desired quantity.
-func (b OrderBook) BestNoTake(quantity int) (Cents, bool) {
+func (b OrderBook) BestNoOffer(quantity int) (Cents, bool) {
 	return b.YesBids.bestPrice(quantity)
 }
 

--- a/orderbook.go
+++ b/orderbook.go
@@ -66,7 +66,7 @@ func (b OrderBookBids) totalOffers() int {
 	return total
 }
 
-func (b OrderBookBids) availableQuantity(limitPrice Cents) int {
+func (b OrderBookBids) offersUnderLimit(limitPrice Cents) int {
 	quantity := 0
 	for i := len(b) - 1; i >= 0; i-- {
 		if 100-b[i].Price > limitPrice {
@@ -77,16 +77,16 @@ func (b OrderBookBids) availableQuantity(limitPrice Cents) int {
 	return quantity
 }
 
-// YesAvailableUnderLimit is the quantity of Yes contracts available to be taken
+// YesOffersUnderLimit is the quantity of Yes contracts available to be taken
 // at a price less than or equal to the given limit.
-func (b OrderBook) YesAvailableUnderLimit(limit Cents) int {
-	return b.NoBids.availableQuantity(limit)
+func (b OrderBook) YesOffersUnderLimit(limit Cents) int {
+	return b.NoBids.offersUnderLimit(limit)
 }
 
-// NoAvailableUnderLimit is the quantity of No contracts available to be taken
+// NoOffersUnderLimit is the quantity of No contracts available to be taken
 // at a price less than or equal to the given limit.
-func (b OrderBook) NoAvailableUnderLimit(limit Cents) int {
-	return b.YesBids.availableQuantity(limit)
+func (b OrderBook) NoOffersUnderLimit(limit Cents) int {
+	return b.YesBids.offersUnderLimit(limit)
 }
 
 // BestYesTake returns the best average
@@ -101,7 +101,8 @@ func (b OrderBook) BestNoTake(quantity int) (Cents, bool) {
 	return b.YesBids.bestPrice(quantity)
 }
 
-// bestPrice returns the best price for average execution.
+// bestPrice returns the best average asking price that a slice of bids
+// provides to the opposite side of the market.
 func (b OrderBookBids) bestPrice(wantQuantity int) (Cents, bool) {
 	var (
 		foundQuantity int

--- a/orderbook_test.go
+++ b/orderbook_test.go
@@ -10,7 +10,7 @@ func TestOrderBook(t *testing.T) {
 	t.Parallel()
 
 	book := OrderBook{
-		YesBids: OrderBookSide{
+		YesBids: OrderBookBids{
 			{1, 2500},
 			{2, 500},
 			{3, 100},
@@ -18,32 +18,49 @@ func TestOrderBook(t *testing.T) {
 	}
 
 	// No book
-	_, ok := book.NoBids.BestPrice(100)
+	_, ok := book.BestYesTake(100)
 	require.False(t, ok)
 
 	var price Cents
 
 	// Since order is small, should execute at best price.
-	price, ok = book.YesBids.BestPrice(10)
+	price, ok = book.BestNoTake(10)
 	require.True(t, ok)
 	require.Equal(t, Cents(97), price)
 
 	// Order too large
-	_, ok = book.YesBids.BestPrice(4000)
+	_, ok = book.BestNoTake(4000)
 	require.False(t, ok)
 
 	// Order is large, executes at worst price
-	price, ok = book.YesBids.BestPrice(3000)
+	price, ok = book.BestNoTake(3000)
 	require.True(t, ok)
 	require.Equal(t, Cents(99), price)
 
 	// Order is large, executes at worst price
-	price, ok = book.YesBids.BestPrice(3000)
+	price, ok = book.BestNoTake(3000)
 	require.True(t, ok)
 	require.Equal(t, Cents(99), price)
 
-	// Order is mid-size, executes at median price.
-	price, ok = book.YesBids.BestPrice(650)
+	price, ok = book.BestNoTake(600)
 	require.True(t, ok)
 	require.Equal(t, Cents(98), price)
+
+	liquidity := book.NoLiquidity()
+	require.Equal(t, Cents(306200), liquidity)
+
+	liquidity = book.YesLiquidity()
+	require.Equal(t, Cents(0), liquidity)
+
+	offers := book.NoTotalOffers()
+	require.Equal(t, 3100, offers)
+
+	offers = book.YesTotalOffers()
+	require.Equal(t, 0, offers)
+
+	offers = book.NoAvailableUnderLimit(Cents(98))
+	require.Equal(t, 600, offers)
+
+	offers = book.YesAvailableUnderLimit(Cents(0))
+	require.Equal(t, 0, offers)
 }

--- a/orderbook_test.go
+++ b/orderbook_test.go
@@ -19,31 +19,31 @@ func TestOrderBook(t *testing.T) {
 	}
 
 	// No book
-	_, ok := book.BestYesTake(100)
+	_, ok := book.BestYesOffer(100)
 	require.False(t, ok)
 
 	var price Cents
 
 	// Since order is small, should execute at best price.
-	price, ok = book.BestNoTake(10)
+	price, ok = book.BestNoOffer(10)
 	require.True(t, ok)
 	require.Equal(t, Cents(97), price)
 
 	// Order too large
-	_, ok = book.BestNoTake(4000)
+	_, ok = book.BestNoOffer(4000)
 	require.False(t, ok)
 
 	// Order is large, executes at worst price
-	price, ok = book.BestNoTake(3000)
+	price, ok = book.BestNoOffer(3000)
 	require.True(t, ok)
 	require.Equal(t, Cents(99), price)
 
 	// Order is large, executes at worst price
-	price, ok = book.BestNoTake(3000)
+	price, ok = book.BestNoOffer(3000)
 	require.True(t, ok)
 	require.Equal(t, Cents(99), price)
 
-	price, ok = book.BestNoTake(600)
+	price, ok = book.BestNoOffer(600)
 	require.True(t, ok)
 	require.Equal(t, Cents(98), price)
 

--- a/orderbook_test.go
+++ b/orderbook_test.go
@@ -10,7 +10,7 @@ func TestOrderBook(t *testing.T) {
 	t.Parallel()
 
 	book := OrderBook{
-		Yes: OrderBookDirection{
+		YesBids: OrderBookSide{
 			{1, 2500},
 			{2, 500},
 			{3, 100},
@@ -18,32 +18,32 @@ func TestOrderBook(t *testing.T) {
 	}
 
 	// No book
-	_, ok := book.No.BestPrice(100)
+	_, ok := book.NoBids.BestPrice(100)
 	require.False(t, ok)
 
 	var price Cents
 
 	// Since order is small, should execute at best price.
-	price, ok = book.Yes.BestPrice(10)
+	price, ok = book.YesBids.BestPrice(10)
 	require.True(t, ok)
-	require.Equal(t, 97, price)
+	require.Equal(t, Cents(97), price)
 
 	// Order too large
-	_, ok = book.Yes.BestPrice(4000)
+	_, ok = book.YesBids.BestPrice(4000)
 	require.False(t, ok)
 
 	// Order is large, executes at worst price
-	price, ok = book.Yes.BestPrice(3000)
+	price, ok = book.YesBids.BestPrice(3000)
 	require.True(t, ok)
-	require.Equal(t, 99, price)
+	require.Equal(t, Cents(99), price)
 
 	// Order is large, executes at worst price
-	price, ok = book.Yes.BestPrice(3000)
+	price, ok = book.YesBids.BestPrice(3000)
 	require.True(t, ok)
-	require.Equal(t, 99, price)
+	require.Equal(t, Cents(99), price)
 
 	// Order is mid-size, executes at median price.
-	price, ok = book.Yes.BestPrice(650)
+	price, ok = book.YesBids.BestPrice(650)
 	require.True(t, ok)
-	require.Equal(t, 98, price)
+	require.Equal(t, Cents(98), price)
 }

--- a/orderbook_test.go
+++ b/orderbook_test.go
@@ -1,6 +1,7 @@
 package kalshi
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -58,9 +59,25 @@ func TestOrderBook(t *testing.T) {
 	offers = book.YesTotalOffers()
 	require.Equal(t, 0, offers)
 
-	offers = book.NoAvailableUnderLimit(Cents(98))
+	offers = book.NoOffersUnderLimit(Cents(98))
 	require.Equal(t, 600, offers)
 
-	offers = book.YesAvailableUnderLimit(Cents(0))
+	offers = book.YesOffersUnderLimit(Cents(0))
 	require.Equal(t, 0, offers)
+}
+
+func TestParseOrderBook(t *testing.T) {
+	t.Parallel()
+	var book OrderBook
+	str := `{"yes": [[19, 132], [18, 58]], "no": []}`
+
+	err := json.Unmarshal([]byte(str), &book)
+	require.NoError(t, err)
+	require.Equal(t, OrderBook{
+		YesBids: OrderBookBids{
+			{Cents(19), 132},
+			{Cents(18), 58},
+		},
+		NoBids: OrderBookBids{},
+	}, book)
 }

--- a/portfolio.go
+++ b/portfolio.go
@@ -36,7 +36,7 @@ const (
 // https://trading-api.readme.io/reference/createorder.
 type CreateOrderRequest struct {
 	Action        OrderAction `json:"action,omitempty"`
-	BuyMaxCost    int         `json:"buy_max_cost,omitempty"`
+	BuyMaxCost    Cents       `json:"buy_max_cost,omitempty"`
 	Count         int         `json:"count,omitempty"`
 	Expiration    *Timestamp  `json:"expiration_ts,omitempty"`
 	NoPrice       Cents       `json:"no_price,omitempty"`
@@ -124,20 +124,20 @@ type Order struct {
 	FccCancelCount   int         `json:"fcc_cancel_count"`
 	LastUpdateTime   *Time       `json:"last_update_time"`
 	MakerFillCount   int         `json:"maker_fill_count"`
-	NoPrice          int         `json:"no_price"`
+	NoPrice          Cents       `json:"no_price"`
 	OrderID          string      `json:"order_id"`
 	PlaceCount       int         `json:"place_count"`
 	QueuePosition    int         `json:"queue_position"`
 	RemainingCount   int         `json:"remaining_count"`
 	Side             Side        `json:"side"`
 	Status           OrderStatus `json:"status"`
-	TakerFees        int         `json:"taker_fees"`
-	TakerFillCost    int         `json:"taker_fill_cost"`
+	TakerFees        Cents       `json:"taker_fees"`
+	TakerFillCost    Cents       `json:"taker_fill_cost"`
 	TakerFillCount   int         `json:"taker_fill_count"`
 	Ticker           string      `json:"ticker"`
 	Type             OrderType   `json:"type"`
 	UserID           string      `json:"user_id"`
-	YesPrice         int         `json:"yes_price"`
+	YesPrice         Cents       `json:"yes_price"`
 }
 
 // Orders is described here:
@@ -183,16 +183,16 @@ func (c *Client) Balance(ctx context.Context) (Cents, error) {
 // Fill is described here:
 // https://trading-api.readme.io/reference/getfills.
 type Fill struct {
-	Action      string    `json:"action"`
-	Count       int       `json:"count"`
-	CreatedTime time.Time `json:"created_time"`
-	IsTaker     bool      `json:"is_taker"`
-	NoPrice     int       `json:"no_price"`
-	OrderID     string    `json:"order_id"`
-	Side        string    `json:"side"`
-	Ticker      string    `json:"ticker"`
-	TradeID     string    `json:"trade_id"`
-	YesPrice    int       `json:"yes_price"`
+	Action      OrderAction `json:"action"`
+	Count       int         `json:"count"`
+	CreatedTime time.Time   `json:"created_time"`
+	IsTaker     bool        `json:"is_taker"`
+	NoPrice     Cents       `json:"no_price"`
+	OrderID     string      `json:"order_id"`
+	Side        Side        `json:"side"`
+	Ticker      string      `json:"ticker"`
+	TradeID     string      `json:"trade_id"`
+	YesPrice    Cents       `json:"yes_price"`
 }
 
 // FillsRequest is described here:

--- a/portfolio.go
+++ b/portfolio.go
@@ -9,26 +9,47 @@ import (
 	"github.com/google/uuid"
 )
 
+type OrderStatus string
+
+const (
+	Resting  OrderStatus = "resting"
+	Canceled OrderStatus = "canceled"
+	Executed OrderStatus = "executed"
+	Pending  OrderStatus = "pending"
+)
+
+type OrderAction string
+
+const (
+	Buy  OrderAction = "buy"
+	Sell OrderAction = "sell"
+)
+
+type OrderType string
+
+const (
+	MarketOrder OrderType = "market"
+	LimitOrder  OrderType = "limit"
+)
+
 // CreateOrderRequest is described here:
 // https://trading-api.readme.io/reference/createorder.
 type CreateOrderRequest struct {
-	// Action is either "buy" or "sell"
-	Action        string    `json:"action,omitempty"`
-	BuyMaxCost    int       `json:"buy_max_cost,omitempty"`
-	Count         int       `json:"count,omitempty"`
-	Expiration    Timestamp `json:"expiration_ts,omitempty"`
-	NoPrice       int       `json:"no_price,omitempty"`
-	YesPrice      int       `json:"yes_price,omitempty"`
-	Ticker        string    `json:"ticker,omitempty"`
-	ClientOrderID string    `json:"client_order_id,omitempty"`
-	// Type is either "market" or "limit"
-	Type string `json:"type"`
-	Side Side   `json:"side"`
+	Action        OrderAction `json:"action,omitempty"`
+	BuyMaxCost    int         `json:"buy_max_cost,omitempty"`
+	Count         int         `json:"count,omitempty"`
+	Expiration    *Timestamp  `json:"expiration_ts,omitempty"`
+	NoPrice       Cents       `json:"no_price,omitempty"`
+	YesPrice      Cents       `json:"yes_price,omitempty"`
+	Ticker        string      `json:"ticker,omitempty"`
+	ClientOrderID string      `json:"client_order_id,omitempty"`
+	Type          OrderType   `json:"type"`
+	Side          Side        `json:"side"`
 }
 
 // String returns a human-readable representation of the order.
 func (c *CreateOrderRequest) String() string {
-	var price int
+	var price Cents
 	if c.Side == Yes {
 		price = c.YesPrice
 	} else {
@@ -40,14 +61,30 @@ func (c *CreateOrderRequest) String() string {
 	)
 }
 
+// When passed to `CreateOrder`, the order will attempt to partially or completely fill
+// and the remaining unfilled quantity will be cancelled.
+// This is also known as Immediate-or-Cancel (IOC).
+func OrderExecuteImmediateOrCancel() *Timestamp {
+	t := Timestamp(time.Now().AddDate(-10, 0, 0))
+	return &t
+}
+
+// ExpireAfter is a helper function for creating an expiration timestamp
+// some duration after the current time.
+func ExpireAfter(duration time.Duration) *Timestamp {
+	t := Timestamp(time.Now().Add(duration))
+	return &t
+}
+
+// When passed to `CreateOrder`, the order won't expire until explicitly cancelled.
+// This is also known as Good 'Till Cancelled (GTC). This function just returns `nil`.
+func OrderGoodTillCanceled() *Timestamp {
+	return nil
+}
+
 // CreateOrder is described here:
 // https://trading-api.readme.io/reference/createorder.
 func (c *Client) CreateOrder(ctx context.Context, req CreateOrderRequest) (*Order, error) {
-	if req.Expiration.Time().IsZero() {
-		// Otherwise, API will fail with obscure error.
-		return nil, fmt.Errorf("expiration is required")
-	}
-
 	if req.ClientOrderID == "" {
 		req.ClientOrderID = uuid.New().String()
 	}
@@ -71,36 +108,36 @@ func (c *Client) CreateOrder(ctx context.Context, req CreateOrderRequest) (*Orde
 // OrdersRequest is described here:
 // https://trading-api.readme.io/reference/getorders
 type OrdersRequest struct {
-	Ticker string `url:"ticker,omitempty"`
-	Status string `url:"status,omitempty"`
+	Ticker string      `url:"ticker,omitempty"`
+	Status OrderStatus `url:"status,omitempty"`
 }
 
 // Order is described here:
 // https://trading-api.readme.io/reference/getorders.
 type Order struct {
-	Action           string `json:"action"`
-	ClientOrderID    string `json:"client_order_id"`
-	CloseCancelCount int    `json:"close_cancel_count"`
-	CreatedTime      *Time  `json:"created_time"`
-	DecreaseCount    int    `json:"decrease_count"`
-	ExpirationTime   *Time  `json:"expiration_time"`
-	FccCancelCount   int    `json:"fcc_cancel_count"`
-	LastUpdateTime   *Time  `json:"last_update_time"`
-	MakerFillCount   int    `json:"maker_fill_count"`
-	NoPrice          int    `json:"no_price"`
-	OrderID          string `json:"order_id"`
-	PlaceCount       int    `json:"place_count"`
-	QueuePosition    int    `json:"queue_position"`
-	RemainingCount   int    `json:"remaining_count"`
-	Side             string `json:"side"`
-	Status           string `json:"status"`
-	TakerFees        int    `json:"taker_fees"`
-	TakerFillCost    int    `json:"taker_fill_cost"`
-	TakerFillCount   int    `json:"taker_fill_count"`
-	Ticker           string `json:"ticker"`
-	Type             string `json:"type"`
-	UserID           string `json:"user_id"`
-	YesPrice         int    `json:"yes_price"`
+	Action           OrderAction `json:"action"`
+	ClientOrderID    string      `json:"client_order_id"`
+	CloseCancelCount int         `json:"close_cancel_count"`
+	CreatedTime      *Time       `json:"created_time"`
+	DecreaseCount    int         `json:"decrease_count"`
+	ExpirationTime   *Time       `json:"expiration_time"`
+	FccCancelCount   int         `json:"fcc_cancel_count"`
+	LastUpdateTime   *Time       `json:"last_update_time"`
+	MakerFillCount   int         `json:"maker_fill_count"`
+	NoPrice          int         `json:"no_price"`
+	OrderID          string      `json:"order_id"`
+	PlaceCount       int         `json:"place_count"`
+	QueuePosition    int         `json:"queue_position"`
+	RemainingCount   int         `json:"remaining_count"`
+	Side             Side        `json:"side"`
+	Status           OrderStatus `json:"status"`
+	TakerFees        int         `json:"taker_fees"`
+	TakerFillCost    int         `json:"taker_fill_cost"`
+	TakerFillCount   int         `json:"taker_fill_count"`
+	Ticker           string      `json:"ticker"`
+	Type             OrderType   `json:"type"`
+	UserID           string      `json:"user_id"`
+	YesPrice         int         `json:"yes_price"`
 }
 
 // Orders is described here:
@@ -250,43 +287,52 @@ func (c *Client) DecreaseOrder(ctx context.Context, orderID string, req Decrease
 	return &resp.Order, nil
 }
 
+type SettlementStatus string
+
+const (
+	StatusAll       SettlementStatus = "all"
+	StatusSettled   SettlementStatus = "settled"
+	StatusUnsettled SettlementStatus = "unsettled"
+)
+
 // Position is described here:
 // https://trading-api.readme.io/reference/getpositions.
 type PositionsRequest struct {
 	CursorRequest
-	// SettlementStatus is one of "all", "settled", or "unsettled".
-	SettlementStatus string `url:"settlement_status,omitempty"`
-	Ticker           string `url:"ticker,omitempty"`
-	EventTicker      string `url:"event_ticker,omitempty"`
+	Limit            int              `url:"limit,omitempty"`
+	SettlementStatus SettlementStatus `url:"settlement_status,omitempty"`
+	Ticker           string           `url:"ticker,omitempty"`
+	EventTicker      string           `url:"event_ticker,omitempty"`
 }
 
 // EventPosition is described here:
 // https://trading-api.readme.io/reference/getpositions.
 type EventPosition struct {
-	EventExposure     int    `json:"event_exposure"`
+	EventExposure     Cents  `json:"event_exposure"`
 	EventTicker       string `json:"event_ticker"`
-	FeesPaid          int    `json:"fees_paid"`
-	RealizedPnl       int    `json:"realized_pnl"`
+	FeesPaid          Cents  `json:"fees_paid"`
+	RealizedPnl       Cents  `json:"realized_pnl"`
 	RestingOrderCount int    `json:"resting_order_count"`
-	TotalCost         int    `json:"total_cost"`
+	TotalCost         Cents  `json:"total_cost"`
 }
 
 // MarketPosition is described here:
 // https://trading-api.readme.io/reference/getpositions.
 type MarketPosition struct {
-	FeesPaid           int    `json:"fees_paid"`
-	FinalPosition      int    `json:"final_position"`
-	FinalPositionCost  int    `json:"final_position_cost"`
-	IsSettled          bool   `json:"is_settled"`
-	LastPosition       int    `json:"last_position"`
-	MarketID           string `json:"market_id"`
-	Position           int    `json:"position"`
-	PositionCost       int    `json:"position_cost"`
-	RealizedPnl        int    `json:"realized_pnl"`
-	RestingOrdersCount int    `json:"resting_orders_count"`
-	TotalCost          int    `json:"total_cost"`
-	UserID             string `json:"user_id"`
-	Volume             int    `json:"volume"`
+	// Fees paid on fill orders, in cents.
+	FeesPaid Cents `json:"fees_paid"`
+	// Number of contracts bought in this market. Negative means NO contracts and positive means YES contracts.
+	Position int `json:"position"`
+	// Locked in profit and loss, in cents.
+	RealizedPnl Cents `json:"realized_pnl"`
+	// Aggregate size of resting orders in contract units.
+	RestingOrdersCount int `json:"resting_orders_count"`
+	// Unique identifier for the market.
+	Ticker string `json:"ticker"`
+	// Total spent on this market in cents.
+	TotalTraded Cents `json:"total_traded"`
+	// Cost of the aggregate market position in cents.
+	MarketExposure Cents `json:"market_exposure"`
 }
 
 // PositionsResponse is described here:

--- a/portfolio_test.go
+++ b/portfolio_test.go
@@ -42,7 +42,7 @@ func TestOrder(t *testing.T) {
 	require.NoError(t, err)
 	t.Logf("book for %s: %+v", testMarket.Ticker, book)
 	if len(book.NoBids) > 0 {
-		bestPrice, ok := book.NoBids.BestPrice(1)
+		bestPrice, ok := book.NoBids.bestPrice(1)
 		if ok {
 			t.Logf("best price: %v", bestPrice)
 		}

--- a/portfolio_test.go
+++ b/portfolio_test.go
@@ -71,7 +71,7 @@ func TestOrder(t *testing.T) {
 		t.Logf("created order: %+v", order)
 		require.True(t, order.ExpirationTime.After((time.Now())))
 		// Market order should execute immediately.
-		require.Equal(t, "executed", order.Status)
+		require.Equal(t, Executed, order.Status)
 		t.Run("Fills", func(t *testing.T) {
 			t.Skip("Doesn't seem to work?")
 			fills, err := client.Fills(ctx, FillsRequest{
@@ -140,7 +140,7 @@ func TestOrder(t *testing.T) {
 		t.Run("Cancel", func(t *testing.T) {
 			order, err := client.CancelOrder(ctx, order.OrderID)
 			require.NoError(t, err)
-			require.Equal(t, order.Status, "canceled")
+			require.Equal(t, Canceled, order.Status)
 		})
 	})
 }

--- a/portfolio_test.go
+++ b/portfolio_test.go
@@ -41,15 +41,15 @@ func TestOrder(t *testing.T) {
 	book, err := client.MarketOrderBook(ctx, testMarket.Ticker)
 	require.NoError(t, err)
 	t.Logf("book for %s: %+v", testMarket.Ticker, book)
-	if len(book.No) > 0 {
-		bestPrice, ok := book.No.BestPrice(1)
+	if len(book.NoBids) > 0 {
+		bestPrice, ok := book.NoBids.BestPrice(1)
 		if ok {
 			t.Logf("best price: %v", bestPrice)
 		}
 	}
 
 	orders, err := client.Orders(ctx, OrdersRequest{
-		Status: "resting",
+		Status: Resting,
 		Ticker: testMarket.Ticker,
 	})
 	require.NoError(t, err)
@@ -57,12 +57,12 @@ func TestOrder(t *testing.T) {
 
 	t.Run("Market", func(t *testing.T) {
 		createReq := CreateOrderRequest{
-			Action:     "buy",
+			Action:     Buy,
 			Count:      1,
-			Expiration: Timestamp(time.Now().Add(time.Minute)),
+			Expiration: ExpireAfter(time.Minute),
 			Ticker:     testMarket.Ticker,
 			BuyMaxCost: 1,
-			Type:       "market",
+			Type:       MarketOrder,
 			Side:       Yes,
 		}
 		t.Logf("create req: %+v", createReq.String())
@@ -86,12 +86,12 @@ func TestOrder(t *testing.T) {
 	t.Run("Limit", func(t *testing.T) {
 		// Testing limit
 		createReq := CreateOrderRequest{
-			Action:     "buy",
+			Action:     Buy,
 			Count:      2,
-			Expiration: Timestamp(time.Now().Add(time.Minute)),
+			Expiration: ExpireAfter(time.Minute),
 			Ticker:     testMarket.Ticker,
 			YesPrice:   1,
-			Type:       "limit",
+			Type:       LimitOrder,
 			Side:       Yes,
 		}
 		order, err := client.CreateOrder(ctx, createReq)
@@ -107,7 +107,7 @@ func TestOrder(t *testing.T) {
 
 		require.Eventually(t, func() bool {
 			orders, err = client.Orders(ctx, OrdersRequest{
-				Status: "resting",
+				Status: Resting,
 				Ticker: testMarket.Ticker,
 			})
 			require.NoError(t, err)


### PR DESCRIPTION
Many breaking changes. @ammario 

Noteworthy changes:
- Parse order book bids into `OrderBookBid` rather than `[2]int`
- Use `*Timestamp` for `CreateOrderRequest` to allow ommitting the field via `nil`. Export helper methods for constructing expirations, `ExpireAfter`, `OrderExecuteImmediateOrCancel`, and `OrderGoodTillCanceled`
- New types for `OrderStatus`, `SettlementStatus`, `OrderType`, `OrderAction`
- Use `Cents` everywhere.
- Adjust semantics of `OrderBook` types and methods to reduce confusion and misuse.
    - export new methods `{Yes,No}Liquidity`, `{Yes,No}OffersUnderLimit`, `Best{Yes,No}Offer`, `{Yes,No}TotalOffers`
